### PR TITLE
Eliminate SMS for Client user number. #324

### DIFF
--- a/restcomm/restcomm.ui/src/main/webapp/modules/modals/modal-register-sip-client.html
+++ b/restcomm/restcomm.ui/src/main/webapp/modules/modals/modal-register-sip-client.html
@@ -50,7 +50,7 @@
                     <rc-endpoint-url method-var="newClient.status_callback_method" url-var="newClient.status_callback_url"></rc-endpoint-url>
                 </dd>
             </dl>
-            <h4>SMS Messaging</h4>
+            <!--h4>SMS Messaging</h4> Commented because Restcomm API, does not support SMS functionality for Users/Clients.
             <dl class="dl-horizontal form-dl">
                 <dt>SMS Request URL</dt>
                 <dd>
@@ -60,7 +60,7 @@
                 <dd>
                     <rc-endpoint-url method-var="newClient.sms_fallback_method" url-var="newClient.sms_fallback_url"></rc-endpoint-url>
                 </dd>
-            </dl>
+            </dl-->
         </div>
     </form>
 </div>

--- a/restcomm/restcomm.ui/src/main/webapp/modules/numbers-clients-details.html
+++ b/restcomm/restcomm.ui/src/main/webapp/modules/numbers-clients-details.html
@@ -62,7 +62,7 @@
         </span>
     </fieldset>
 </div>
-<div class="well well-sm">
+<!--div class="well well-sm"> Commented because Restcomm API, does not support SMS functionality for Users/Clients.
     <h3 class="text-muted details-header">SMS</h3>
     <fieldset>
         <label class="pull-left" for="sms-url">
@@ -81,7 +81,7 @@
             <rc-endpoint-url method-var="clientDetails.sms_fallback_method" url-var="clientDetails.sms_fallback_url"></rc-endpoint-url>
         </span>
     </fieldset>
-</div>
+</div-->
 <div class="">
     <button class="btn btn-primary" ng-click="updateSIPClient(clientDetails)">Save Changes</button>
     <a href="#/numbers/clients" class="btn">Close</a>


### PR DESCRIPTION
When a Sip client user is created or modified, it is possible to setup a SMS Request URL & SMS Fallback URL. But Restcomm API, in not supporting this kind of actions.

http://docs.telestax.com/restcomm-api-clients/
