### PR TITLE
ISSUE-366 DialCallStatus should use no-answer instead of NO_ANSWER

### DIFF
--- a/restcomm/restcomm.interpreter/src/main/java/org/mobicents/servlet/restcomm/interpreter/VoiceInterpreter.java
+++ b/restcomm/restcomm.interpreter/src/main/java/org/mobicents/servlet/restcomm/interpreter/VoiceInterpreter.java
@@ -1686,13 +1686,13 @@ public final class VoiceInterpreter extends BaseVoiceInterpreter {
                 parameters.add(new BasicNameValuePair("DialCallSid", dialCallSid));
                 // parameters.add(new BasicNameValuePair("DialCallStatus", dialCallStatus == null ? null : dialCallStatus
                 // .toString()));
-                parameters.add(new BasicNameValuePair("DialCallStatus", CallStateChanged.State.NO_ANSWER.name()));
+                parameters.add(new BasicNameValuePair("DialCallStatus", CallStateChanged.State.NO_ANSWER.toString()));
                 parameters.add(new BasicNameValuePair("DialCallDuration", String.valueOf(dialCallDuration)));
                 parameters.add(new BasicNameValuePair("RecordingUrl", recordingUrl));
                 parameters.add(new BasicNameValuePair("PublicRecordingUrl", publicRecordingUrl));
             } else {
                 parameters.add(new BasicNameValuePair("DialCallSid", null));
-                parameters.add(new BasicNameValuePair("DialCallStatus", CallStateChanged.State.NO_ANSWER.name()));
+                parameters.add(new BasicNameValuePair("DialCallStatus", CallStateChanged.State.NO_ANSWER.toString()));
                 parameters.add(new BasicNameValuePair("DialCallDuration", "0"));
                 parameters.add(new BasicNameValuePair("RecordingUrl", null));
                 parameters.add(new BasicNameValuePair("PublicRecordingUrl", null));

--- a/restcomm/restcomm.testsuite/src/test/java/org/mobicents/servlet/restcomm/telephony/DialActionTest.java
+++ b/restcomm/restcomm.testsuite/src/test/java/org/mobicents/servlet/restcomm/telephony/DialActionTest.java
@@ -508,7 +508,7 @@ public class DialActionTest {
         assertTrue(!data.getFirst("DialCallSid").equalsIgnoreCase(""));
         assertTrue(data.getFirst("RecordingUrl").equalsIgnoreCase(""));
         assertTrue(data.getFirst("PublicRecordingUrl").equalsIgnoreCase(""));
-        assertTrue(data.getFirst("DialCallStatus").equalsIgnoreCase("no_answer"));
+        assertTrue(data.getFirst("DialCallStatus").equalsIgnoreCase("no-answer"));
         assertTrue(data.getFirst("DialCallDuration").equalsIgnoreCase("3"));
 
         assertTrue(data.getFirst("To").equalsIgnoreCase("+12223334455"));


### PR DESCRIPTION
Fixes #366 Assuming the documentation is correct, this PR updates the code to match the doc. Not tested at all.