### PR TITLE
Combine both implementations of getNetwork()

### DIFF
--- a/release/config-scripts/as7-config-scripts/restcomm/utils/read-network-props.sh
+++ b/release/config-scripts/as7-config-scripts/restcomm/utils/read-network-props.sh
@@ -30,7 +30,7 @@ getSubnetMask() {
 ## Parameters : 1.Private IP
 ## 				2.Subnet Mask
 getNetwork() {
-  ipcalc -n $1 $2 | grep -i "Network" | awk '{print $2}' | awk -F/ '{print $1}';
+        ipcalc -n $1 $2 | grep -i "Network" | awk -F= '{print $2}';
 }
 
 # MAIN

--- a/release/config-scripts/as7-config-scripts/restcomm/utils/read-network-props.sh
+++ b/release/config-scripts/as7-config-scripts/restcomm/utils/read-network-props.sh
@@ -30,7 +30,13 @@ getSubnetMask() {
 ## Parameters : 1.Private IP
 ## 				2.Subnet Mask
 getNetwork() {
-        ipcalc -n $1 $2 | grep -i "Network" | awk -F= '{print $2}';
+        #debian/ubuntu
+        NW=`ipcalc -n $1 $2 | grep -i "Network" | awk '{print $2}' | awk -F/ '{print $1}';`
+        if [[ -z "$NW" ]]; then
+            #rhel/centos/amazon
+            NW=`ipcalc -n $1 $2 | grep -i "Network" | awk -F= '{print $2}';`
+        fi
+        echo $NW
 }
 
 # MAIN

--- a/release/config-scripts/utils/read-network-props.sh
+++ b/release/config-scripts/utils/read-network-props.sh
@@ -36,7 +36,13 @@ getSubnetMask() {
 ## Parameters : 1.Private IP
 ## 				2.Subnet Mask
 getNetwork() {
-	ipcalc -n $1 $2 | grep -i "Network" | awk -F= '{print $2}';
+        #debian/ubuntu
+        NW=`ipcalc -n $1 $2 | grep -i "Network" | awk '{print $2}' | awk -F/ '{print $1}';`
+        if [[ -z "$NW" ]]; then
+            #rhel/centos/amazon
+            NW=`ipcalc -n $1 $2 | grep -i "Network" | awk -F= '{print $2}';`
+        fi
+        echo $NW
 }
 
 # MAIN


### PR DESCRIPTION
I'm finding that, out of the two differently implemented versions of getNetwork(), one works for me (on CentOS) and one doesn't. This PR replaces the one that doesn't work with the one that does.