### PR TITLE
#421 If ipecho.net is not responding, try observebox.com

### DIFF
--- a/release/config-scripts/utils/read-network-props.sh
+++ b/release/config-scripts/utils/read-network-props.sh
@@ -17,7 +17,16 @@ getPrivateIP() {
 ## Description: Gets the public IP of the instance 
 ## Parameters : none
 getPublicIP() {
-	wget -qO- http://ipecho.net/plain
+        PIP=`wget --tries=5 --timeout=5 -qO- http://ipecho.net/plain`
+        if [[ -z "$PIP" ]]; then
+            echo "Could not determine public IP via ipecho.net, trying observebox.com"
+            PIP=`wget --tries=5 --timeout=5 -qO- http://observebox.com/ip`
+        fi
+        if [[ -z "$PIP" ]]; then
+            echo "Failed to determine public IP"
+            exit 1;
+        fi
+        echo $PIP
 }
 
 ## Description: Gets the broadcast address of the instance 

--- a/release/config-scripts/utils/read-network-props.sh
+++ b/release/config-scripts/utils/read-network-props.sh
@@ -19,7 +19,7 @@ getPrivateIP() {
 getPublicIP() {
         PIP_IP=`wget --tries=5 --timeout=5 -qO- http://ipecho.net/plain`
         if [[ -z "$PIP_IP" ]]; then
-            PIP=`wget --tries=5 --timeout=5 -qO- http://observebox.com/ip`
+            PIP=`wget --tries=5 --timeout=5 -qO- http://ip-addr.es`
         fi
         if [[ -z "$PIP" ]]; then
             echo "Failed to determine public IP"

--- a/release/config-scripts/utils/read-network-props.sh
+++ b/release/config-scripts/utils/read-network-props.sh
@@ -17,16 +17,16 @@ getPrivateIP() {
 ## Description: Gets the public IP of the instance 
 ## Parameters : none
 getPublicIP() {
-        PIP=`wget --tries=5 --timeout=5 -qO- http://ipecho.net/plain`
-        if [[ -z "$PIP" ]]; then
-            echo "Could not determine public IP via ipecho.net, trying observebox.com"
+        PIP_IP=`wget --tries=5 --timeout=5 -qO- http://ipecho.net/plain`
+        if [[ -z "$PIP_IP" ]]; then
             PIP=`wget --tries=5 --timeout=5 -qO- http://observebox.com/ip`
         fi
         if [[ -z "$PIP" ]]; then
             echo "Failed to determine public IP"
             exit 1;
+        else
+            echo $PIP
         fi
-        echo $PIP
 }
 
 ## Description: Gets the broadcast address of the instance 


### PR DESCRIPTION
As per #421, if ipecho.net is does not respond in 5 attempts, try observebox.com for 5 attempts.

Something else that's also different to the current implementation, only 10 attempts will be made overall and if they fail then the script will exit with a failure message, rather than hanging indefinitely.
