### PR TITLE
Test whether <Dial callerId> is honoured when from-address-to-proxied-calls is true

### DIFF
--- a/restcomm/restcomm.testsuite/src/test/java/org/mobicents/servlet/restcomm/telephony/DialTest.java
+++ b/restcomm/restcomm.testsuite/src/test/java/org/mobicents/servlet/restcomm/telephony/DialTest.java
@@ -1152,7 +1152,7 @@ public class DialTest {
         assertTrue(georgeCall.sendIncomingCallResponse(Response.OK, "OK-George", 3600, receivedBody, "application", "sdp",
                 null, null));
         // the number dialed uses a callerId of "+13055872294", which is what George should receive
-        assertEquals("sip:+13055872294@127.0.0.1:5080", georgeCall.getLastReceivedRequest().getMessage().getHeader("Contact"));
+        assertEquals("Contact: \"+13055872294\" <sip:+13055872294@127.0.0.1:5080>", georgeCall.getLastReceivedRequest().getMessage().getHeader("Contact"));
         assertTrue(georgeCall.waitForAck(50 * 1000));
 
         Thread.sleep(3000);

--- a/restcomm/restcomm.testsuite/src/test/java/org/mobicents/servlet/restcomm/telephony/DialTest.java
+++ b/restcomm/restcomm.testsuite/src/test/java/org/mobicents/servlet/restcomm/telephony/DialTest.java
@@ -1147,9 +1147,12 @@ public class DialTest {
 
         assertTrue(georgeCall.waitForIncomingCall(30 * 1000));
         assertTrue(georgeCall.sendIncomingCallResponse(Response.RINGING, "Ringing-George", 3600));
-        String receivedBody = new String(georgeCall.getLastReceivedRequest().getRawContent());
+        final SipRequest lastRequest = georgeCall.getLastReceivedRequest();
+        String receivedBody = new String(lastRequest.getRawContent());
         assertTrue(georgeCall.sendIncomingCallResponse(Response.OK, "OK-George", 3600, receivedBody, "application", "sdp",
                 null, null));
+        // the number dialed uses a callerId of "+13055872294", which is what George should receive
+        assertEquals("sip:+13055872294@127.0.0.1:5080", georgeCall.getLastReceivedRequest().getMessage().getHeader("Contact"));
         assertTrue(georgeCall.waitForAck(50 * 1000));
 
         Thread.sleep(3000);


### PR DESCRIPTION
Attempt at defining what the caller ID should look like when callerId attribute is specified on a Dial tag, even though \<from-address-to-proxied-calls\> is set to true.